### PR TITLE
Conditional Hashable and Sendable conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,25 @@ on:
   pull_request:
     branches:
       - '*'
+  workflow_dispatch:
 
 jobs:
   library:
-    runs-on: macos-11.0
     environment: default
     strategy:
       matrix:
-        xcode:
-          - '12.4'
-          - '12.5.1'
-          - '13.2'
+        include:
+          - os: macos-11
+            xcode: '12.4' # swift 5.3
+          - os: macos-11
+            xcode: '12.5.1' # swift 5.4
+          - os: macos-12
+            xcode: '13.2.1' # swift 5.5
+          - os: macos-12
+            xcode: '13.4' # swift 5.6
+          - os: macos-12
+            xcode: '14.2' # swift 5.7
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode ${{ matrix.xcode }}
@@ -27,8 +35,9 @@ jobs:
       - name: Lint
         run: swiftlint .
       - name: Run Tests
-        run: swift test --enable-code-coverage
+        run: swift test --enable-code-coverage --parallel
       - name: Swift Coverage Report
-        uses: maxep/spm-lcov-action@0.3.1
-      - name: Code Coverage
-        run: bash <(curl -s https://codecov.io/bash) -X xcodellvm
+        run: xcrun llvm-cov export -format="lcov" .build/debug/SwiftFilterPackageTests.xctest/Contents/MacOS/SwiftFilterPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage_report.lcov
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true # optional (default = false)

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 Package.resolved
+/.swiftpm

--- a/Sources/SwiftFilter/Comparable/AnyComparablePredicate.swift
+++ b/Sources/SwiftFilter/Comparable/AnyComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Comparable/ComparableFilter.swift
+++ b/Sources/SwiftFilter/Comparable/ComparableFilter.swift
@@ -46,3 +46,7 @@ public enum ComparableFilter<T: Comparable>: Equatable {
         }
     }
 }
+
+extension ComparableFilter: Hashable where T: Hashable {}
+
+extension ComparableFilter.Optional: Hashable where T: Hashable {}

--- a/Sources/SwiftFilter/Comparable/ComparableFilter.swift
+++ b/Sources/SwiftFilter/Comparable/ComparableFilter.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 
@@ -12,7 +12,8 @@ import Foundation
 ///
 /// When using indirect cases for compound comparisons it is best to place more simple comparisons
 /// towards the outside and nest more complicated comparisons inside. When building a NSCompoundPredicate from
-/// a filter the outer most filters will be placed first in the array of NSPredicates. Similarly, when bulding a closure the structure
+/// a filter the outer most filters will be placed first in the array of NSPredicates. Similarly, when bulding a closure
+/// the structure
 /// is maintained so that the outer most is evaluated first.
 public enum ComparableFilter<T: Comparable>: Equatable {
     case lessThan(T)

--- a/Sources/SwiftFilter/Comparable/ComparablePredicate.swift
+++ b/Sources/SwiftFilter/Comparable/ComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Comparable/OptionalAnyComparablePredicate.swift
+++ b/Sources/SwiftFilter/Comparable/OptionalAnyComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Comparable/OptionalComparablePredicate.swift
+++ b/Sources/SwiftFilter/Comparable/OptionalComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Equatable/AnyEquatablePredicate.swift
+++ b/Sources/SwiftFilter/Equatable/AnyEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Equatable/EquatableFilter.swift
+++ b/Sources/SwiftFilter/Equatable/EquatableFilter.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 
@@ -12,7 +12,8 @@ import Foundation
 ///
 /// When using indirect cases for compound statements it is best to place more simple operations
 /// towards the outside and nest more complicated operations inside. When building a NSCompoundPredicate from
-/// a filter the outer most filters will be placed first in the array of NSPredicates. Similarly, when bulding a closure the structure
+/// a filter the outer most filters will be placed first in the array of NSPredicates. Similarly, when bulding a closure
+/// the structure
 /// is maintained so that the outer most is evaluated first.
 public enum EquatableFilter<T: Equatable>: Equatable {
     case equalTo(T)

--- a/Sources/SwiftFilter/Equatable/EquatableFilter.swift
+++ b/Sources/SwiftFilter/Equatable/EquatableFilter.swift
@@ -42,3 +42,7 @@ public enum EquatableFilter<T: Equatable>: Equatable {
         }
     }
 }
+
+extension EquatableFilter: Hashable where T: Hashable {}
+
+extension EquatableFilter.Optional: Hashable where T: Hashable {}

--- a/Sources/SwiftFilter/Equatable/EquatablePredicate.swift
+++ b/Sources/SwiftFilter/Equatable/EquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Equatable/OptionalAnyEquatablePredicate.swift
+++ b/Sources/SwiftFilter/Equatable/OptionalAnyEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilter/Equatable/OptionalEquatablePredicate.swift
+++ b/Sources/SwiftFilter/Equatable/OptionalEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilterClosure/Closure+ComparablePredicate.swift
+++ b/Sources/SwiftFilterClosure/Closure+ComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Sources/SwiftFilterClosure/Closure+EquatablePredicate.swift
+++ b/Sources/SwiftFilterClosure/Closure+EquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Sources/SwiftFilterClosure/Closure+OptionalComparablePredicate.swift
+++ b/Sources/SwiftFilterClosure/Closure+OptionalComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter
@@ -12,7 +12,8 @@ import SwiftFilter
 extension Closure: OptionalComparablePredicate where Value: Comparable {
     /// Creates a closure `(Self) -> Bool` from a ComparableFilter.Optional
     ///
-    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting NSPredicate.
+    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting
+    /// NSPredicate.
     public static func build(from filter: ComparableFilter<Value>.Optional,
                              on keyPath: KeyPath<Root, Value?>) -> ((Root) -> Bool)
     {

--- a/Sources/SwiftFilterClosure/Closure+OptionalEquatablePredicate.swift
+++ b/Sources/SwiftFilterClosure/Closure+OptionalEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Sources/SwiftFilterClosure/Closure.swift
+++ b/Sources/SwiftFilterClosure/Closure.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Sources/SwiftFilterNSPredicate/NSExpression+ComparableOperators.swift
+++ b/Sources/SwiftFilterNSPredicate/NSExpression+ComparableOperators.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilterNSPredicate/NSExpression+EquatableOperators.swift
+++ b/Sources/SwiftFilterNSPredicate/NSExpression+EquatableOperators.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilterNSPredicate/NSPredicate+AnyComparablePredicate.swift
+++ b/Sources/SwiftFilterNSPredicate/NSPredicate+AnyComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter
@@ -46,7 +46,8 @@ extension NSPredicate: AnyComparablePredicate {
 
     /// Creates a NSPredicate from a ComparableFilter.Optional
     ///
-    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting NSPredicate.
+    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting
+    /// NSPredicate.
     /// - Parameter keyPath: A keypath instructing what value to use for evaluating the predicate.
     public static func build<Root, Value>(
         from filter: ComparableFilter<Value>,

--- a/Sources/SwiftFilterNSPredicate/NSPredicate+AnyEquatablePredicate.swift
+++ b/Sources/SwiftFilterNSPredicate/NSPredicate+AnyEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Sources/SwiftFilterNSPredicate/NSPredicate+CompoundOperators.swift
+++ b/Sources/SwiftFilterNSPredicate/NSPredicate+CompoundOperators.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Sources/SwiftFilterNSPredicate/NSPredicate+OptionalAnyComparablePredicate.swift
+++ b/Sources/SwiftFilterNSPredicate/NSPredicate+OptionalAnyComparablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter
@@ -12,7 +12,8 @@ import SwiftFilter
 extension NSPredicate: OptionalAnyComparablePredicate {
     /// Creates a NSPredicate from a ComparableFilter.Optional
     ///
-    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting NSPredicate.
+    /// - Parameter filter: An instance of ComparableFilter.Optional representing the logic of the resulting
+    /// NSPredicate.
     /// - Parameter keyPath: A keypath instructing what value to use for evaluating the predicate.
     public static func build<Root, Value>(
         from filter: ComparableFilter<Value>.Optional,

--- a/Sources/SwiftFilterNSPredicate/NSPredicate+OptionalAnyEquatablePredicate.swift
+++ b/Sources/SwiftFilterNSPredicate/NSPredicate+OptionalAnyEquatablePredicate.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 import SwiftFilter

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import XCTest
 

--- a/Tests/SwiftFilterClosureTests/ClosureXCTestManifests.swift
+++ b/Tests/SwiftFilterClosureTests/ClosureXCTestManifests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import XCTest
 

--- a/Tests/SwiftFilterClosureTests/ComparableFilterClosureTests.swift
+++ b/Tests/SwiftFilterClosureTests/ComparableFilterClosureTests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import SwiftFilter
 import SwiftFilterClosure

--- a/Tests/SwiftFilterClosureTests/EquatableFilterClosureTests.swift
+++ b/Tests/SwiftFilterClosureTests/EquatableFilterClosureTests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import SwiftFilter
 import SwiftFilterClosure

--- a/Tests/SwiftFilterNSPredicateTests/ComparableFilterNSPredicateTests.swift
+++ b/Tests/SwiftFilterNSPredicateTests/ComparableFilterNSPredicateTests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import SwiftFilter
 import SwiftFilterNSPredicate

--- a/Tests/SwiftFilterNSPredicateTests/EquatableFilterNSPredicateTests.swift
+++ b/Tests/SwiftFilterNSPredicateTests/EquatableFilterNSPredicateTests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import SwiftFilter
 import SwiftFilterClosure

--- a/Tests/SwiftFilterNSPredicateTests/NSPredicate+ClosureHelper.swift
+++ b/Tests/SwiftFilterNSPredicateTests/NSPredicate+ClosureHelper.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import Foundation
 

--- a/Tests/SwiftFilterNSPredicateTests/NSPredicateXCTestManifests.swift
+++ b/Tests/SwiftFilterNSPredicateTests/NSPredicateXCTestManifests.swift
@@ -4,7 +4,7 @@
 //
 // MIT License
 //
-// Copyright © 2021 Andrew Roan
+// Copyright © 2022 Andrew Roan
 
 import XCTest
 


### PR DESCRIPTION
- Add conditional Hashable and Sendable conformance to EquatableFilter and ComparableFilter
- Run swiftformat
- gitignore .swiftpm to avoid exporting targets downstream